### PR TITLE
Make rngfix_downhill/uphill set velocity without TeleportEntity

### DIFF
--- a/plugin/scripting/rngfix.sp
+++ b/plugin/scripting/rngfix.sp
@@ -1100,7 +1100,7 @@ bool DoInclineCollisionFixes(int client, const float nrm[3])
 	}
 	else
 	{
-		SetVelocity(client, newVelocity);
+		SetVelocity(client, newVelocity, true);
 	}
 
 	return true;


### PR DESCRIPTION
rngfix_downhill/uphill was not using dontUseTeleportEntity which made it TeleportEntity the client which led to behaviour such as OnEndTouch/OnStartTouch activating if the client was inside a trigger when they hit a downhill slope. Mildly tested but it seems fine. Fix by @followingthefasciaplane